### PR TITLE
Add minimal API server for invoice generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,32 @@ const authorizationResult = await documentAuthorization(
 Un ejemplo completo lo puedes encontrar en la carpeta `tests`
 Ejemplos de los archivos generados los encuentras en `src/example`
 
+### API
+
+El repositorio incluye un peque\u00f1o servidor HTTP que expone las funciones de
+facturaci\u00f3n como una API. Para usarlo define las variables de entorno
+`SRI_RECEPTION_URL` y `SRI_AUTHORIZATION_URL` y ejecuta:
+
+```bash
+npm run start:api
+```
+
+El servidor se inicia en el puerto `3000` (o el que especifiques en `PORT`).
+Env\u00eda una petici\u00f3n `POST` a `/invoice` con el siguiente formato:
+
+```json
+{
+  "invoiceData": { /* datos de la factura */ },
+  "p12Path": "./firma.p12",
+  "p12Password": "contraseña"
+}
+```
+
+El campo `obligadoContabilidad` se establece autom\u00e1ticamente en `"SI"` para
+cumplir con la obligaci\u00f3n de llevar contabilidad. La respuesta contiene la
+factura generada, el XML firmado y los resultados de recepci\u00f3n y
+autorizaci\u00f3n.
+
 ### Endpoints del SRI
 
 El SRI ha habilitado dos endpoints para cada ambiente (pruebas, producción).

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "scripts": {
     "build": "tsup",
     "start": "tsc ./src/index.ts",
-    "publish-changes": "npm run build & npm link & npm link open-factura & npm publish"
+    "publish-changes": "npm run build & npm link & npm link open-factura & npm publish",
+    "start:api": "ts-node src/api/server.ts"
   },
   "devDependencies": {
     "bun-types": "latest",

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1,0 +1,68 @@
+import { createServer } from 'http';
+import {
+  generateInvoice,
+  generateInvoiceXml,
+  getP12FromLocalFile,
+  signXml,
+  documentReception,
+  documentAuthorization,
+  InvoiceInput,
+} from '../index';
+
+const port = parseInt(process.env.PORT || '3000');
+
+function sendJson(res: any, status: number, body: any) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+const server = createServer((req, res) => {
+  if (req.method === 'POST' && req.url === '/invoice') {
+    let body = '';
+    req.on('data', (chunk) => (body += chunk));
+    req.on('end', async () => {
+      try {
+        const data = JSON.parse(body);
+        const invoiceData: InvoiceInput = data.invoiceData;
+        const p12Path: string = data.p12Path;
+        const p12Password: string = data.p12Password;
+        if (!invoiceData || !p12Path || !p12Password) {
+          sendJson(res, 400, { error: 'invoiceData, p12Path and p12Password are required' });
+          return;
+        }
+        // Ensure "obligadoContabilidad" is always "SI" as required by accounting rules
+        if (invoiceData.infoFactura) {
+          invoiceData.infoFactura.obligadoContabilidad = 'SI';
+        }
+        const { invoice, accessKey } = generateInvoice(invoiceData);
+        const invoiceXml = generateInvoiceXml(invoice);
+        const p12 = getP12FromLocalFile(p12Path);
+        const signed = await signXml(p12, p12Password, invoiceXml);
+        const reception = await documentReception(
+          signed,
+          process.env.SRI_RECEPTION_URL || ''
+        );
+        const authorization = await documentAuthorization(
+          accessKey,
+          process.env.SRI_AUTHORIZATION_URL || ''
+        );
+        sendJson(res, 200, {
+          invoice,
+          invoiceXml,
+          signedInvoice: signed,
+          reception,
+          authorization,
+        });
+      } catch (err: any) {
+        sendJson(res, 500, { error: err.message });
+      }
+    });
+  } else {
+    res.writeHead(404);
+    res.end();
+  }
+});
+
+server.listen(port, () => {
+  console.log(`Open Factura API listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- add a simple HTTP server exposing invoice operations
- document the new API usage
- provide npm script `start:api`

## Testing
- `npm run build` *(fails: tsup not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e2f9d90c0832788fc7625ddff8333